### PR TITLE
fix: input comma seperated

### DIFF
--- a/webUI/jobme_ui/src/components/JobMatchLLM.js
+++ b/webUI/jobme_ui/src/components/JobMatchLLM.js
@@ -14,9 +14,9 @@ export default function JobMatchLLM() {
 
     const handleSubmit = () => {    
         
-        const skills = document.getElementById("skills").value
-        console.log("Skills: " + skills)
-
+        let skills = document.getElementById("skills").value
+        skills = skills.split(",").map(skill => skill.trim());
+        console.log("Skills: " + skills);
         
         backend.makePrediction(skills).then((result) => {
             setPredictions(result)


### PR DESCRIPTION
Previously, we had to enter our skills in this format : ["python", "Java", "C#"] Which is not user friendly. 
In this PR, we fix this issue. All the user have to enter is a comma seperated skills. 
If the user enters a non comma seperated skills. They will be considered as a single skill and it will effect the performance of the model. 

In the next fix we aim to solve this issue. we aim to give the user the flexibility to enter the skills in the format he/she wants. 